### PR TITLE
One shot prompting is also implemented

### DIFF
--- a/Sage_Server/server.js
+++ b/Sage_Server/server.js
@@ -67,6 +67,9 @@ Keep the tone consistent with the selected setting.
 //
 // Zero-shot prompting is supported: If you send only { user_input: "..." } (with history omitted or empty),
 // the Sage will respond as if it's the first turn, using only the system prompt and your input.
+//
+// One-shot prompting is also supported: If you send { history: [ { role: 'user', text: '...' } ], user_input: "..." },
+// the Sage will respond using the system prompt, the single previous user turn, and your new input.
 app.post('/aetherium-turn', async (req, res) => {
 	try {
 		const { history = [], user_input = '' } = req.body;


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added documentation for one-shot prompting support

- Clarified API usage patterns in comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  API["API Endpoint"] -- "enhanced with" --> DOC["One-shot Documentation"]
  DOC -- "explains" --> USAGE["Usage Pattern"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Document one-shot prompting support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sage_Server/server.js

<ul><li>Added comment explaining one-shot prompting functionality<br> <li> Enhanced API documentation with usage example</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S89_Aetherium_Sage/pull/4/files#diff-97dc9163374f449bbbe44f3b3c0ac8034934029a9402e1f8fd3ad5ef6f247cd6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

